### PR TITLE
feat: Cancel export option

### DIFF
--- a/src/core/filehandling/rpak.cpp
+++ b/src/core/filehandling/rpak.cpp
@@ -144,7 +144,7 @@ void HandlePakAssetExportList(std::deque<CAsset*> selectedAssets, const bool exp
             }, 1u);
     }
 
-    const ProgressBarEvent_t* const exportAssetListEvent = g_pImGuiHandler->AddProgressBarEvent("Exporting asset list..", parallelProcessTask.getRemainingTasks(), &parallelProcessTask, PB_FNCLASS_TO_VOID(&CParallelTask::getRemainingTasks));
+    const ProgressBarEvent_t* const exportAssetListEvent = g_pImGuiHandler->AddProgressBarEvent("Exporting asset list..", parallelProcessTask.getRemainingTasks(), &parallelProcessTask, PB_FNCLASS_TO_VOID(&CParallelTask::getRemainingTasks), true);
     parallelProcessTask.execute();
     parallelProcessTask.wait();
     g_pImGuiHandler->FinishProgressBarEvent(exportAssetListEvent);
@@ -165,7 +165,7 @@ void HandleExportAllPakAssets(std::vector<CGlobalAssetData::AssetLookup_t>* cons
             }, 1u);
     }
 
-    const ProgressBarEvent_t* const exportAllAssetsEvent = g_pImGuiHandler->AddProgressBarEvent("Exporting all assets..", parallelProcessTask.getRemainingTasks(), &parallelProcessTask, PB_FNCLASS_TO_VOID(&CParallelTask::getRemainingTasks));
+    const ProgressBarEvent_t* const exportAllAssetsEvent = g_pImGuiHandler->AddProgressBarEvent("Exporting all assets..", parallelProcessTask.getRemainingTasks(), &parallelProcessTask, PB_FNCLASS_TO_VOID(&CParallelTask::getRemainingTasks), true);
     parallelProcessTask.execute();
     parallelProcessTask.wait();
     g_pImGuiHandler->FinishProgressBarEvent(exportAllAssetsEvent);

--- a/src/core/utils/thread.h
+++ b/src/core/utils/thread.h
@@ -117,11 +117,26 @@ private:
     std::queue<std::function<void()>> tasks;
     std::mutex queueMutex;
     uint32_t maxConcurrentThreads;
+    std::atomic<bool> stopRequested{false};
+
+public:
+    void requestStop()
+    {
+        stopRequested = true;
+    }
+
+    bool isStopRequested() const
+    {
+        return stopRequested;
+    }
 
     void workerThread()
     {
         while (true)
         {
+            if (isStopRequested())
+                break;
+
             std::function<void()> task;
             {
                 std::unique_lock<std::mutex> lock(queueMutex);

--- a/src/thirdparty/imgui/misc/imgui_utility.h
+++ b/src/thirdparty/imgui/misc/imgui_utility.h
@@ -31,6 +31,7 @@ struct ProgressBarEvent_t
 
     bool slotIsUsed;
     bool isInverted;
+    bool hasCloseButton;
     const char* eventName;
     uint32_t eventNum;
     std::atomic<uint32_t>* remainingEvents;
@@ -48,7 +49,7 @@ public:
     void HelpMarker(const char* const desc);
 
     template <typename T>
-    const ProgressBarEvent_t* const AddProgressBarEvent(const char* const eventName, const uint32_t eventNum, T const eventClass, void* const fnRemainingEvents)
+    const ProgressBarEvent_t* const AddProgressBarEvent(const char* const eventName, const uint32_t eventNum, T const eventClass, void* const fnRemainingEvents, const bool hasCloseButton = false)
     {
         std::unique_lock<std::mutex> lock(eventMutex);
         if (eventNum != 0 && !pbAvailSlots.empty())
@@ -63,6 +64,7 @@ public:
             event->remainingEvents = nullptr;
             event->eventClass = reinterpret_cast<void*>(eventClass);
             event->fnRemainingEvents = fnRemainingEvents;
+            event->hasCloseButton = hasCloseButton;
 
             event->slotIsUsed = true;
             return event;
@@ -75,7 +77,7 @@ public:
         unreachable();
     }
 
-    const ProgressBarEvent_t* const AddProgressBarEvent(const char* const eventName, const uint32_t eventNum, std::atomic<uint32_t>* const remainingEvents, const bool isInverted);
+    const ProgressBarEvent_t* const AddProgressBarEvent(const char* const eventName, const uint32_t eventNum, std::atomic<uint32_t>* const remainingEvents, const bool isInverted, const bool hasCloseButton = false);
     void FinishProgressBarEvent(const ProgressBarEvent_t* const event);
     void HandleProgressBar();
 


### PR DESCRIPTION
This **enhancement** adds a cancel export option that allows users to cancel the export process

Enhancement/issue #11 can be closed if this pr gets accepted


## Copilots summary:
This pull request introduces enhancements to the progress bar functionality, including the addition of a close button, integration with task interruption, and improvements to the `CParallelTask` class. These changes improve user experience and provide better control over long-running tasks in the application.

### Progress Bar Enhancements:
* Added a `hasCloseButton` parameter to the `AddProgressBarEvent` method in `ImGuiHandler`, allowing progress bars to include a close button. (`src/thirdparty/imgui/misc/imgui_utility.h`, `src/thirdparty/imgui/misc/imgui_utility.cpp`) [[1]](diffhunk://#diff-4768eb2146ecfefe2394dc6f14307afcfb72a2f96005faaa955a5a1c808e5c5dL250-R250) [[2]](diffhunk://#diff-4768eb2146ecfefe2394dc6f14307afcfb72a2f96005faaa955a5a1c808e5c5dR266) [[3]](diffhunk://#diff-340f02662d4a8b3e0b69cc74475dfe9c65b299091111531cb7fcc66a50cf1a6dL51-R52) [[4]](diffhunk://#diff-340f02662d4a8b3e0b69cc74475dfe9c65b299091111531cb7fcc66a50cf1a6dL78-R80)
* Modified `HandleProgressBar` to handle the close button's state and signal task interruption when the button is clicked. (`src/thirdparty/imgui/misc/imgui_utility.cpp`) [[1]](diffhunk://#diff-4768eb2146ecfefe2394dc6f14307afcfb72a2f96005faaa955a5a1c808e5c5dL300-R306) [[2]](diffhunk://#diff-4768eb2146ecfefe2394dc6f14307afcfb72a2f96005faaa955a5a1c808e5c5dL317-R322) [[3]](diffhunk://#diff-4768eb2146ecfefe2394dc6f14307afcfb72a2f96005faaa955a5a1c808e5c5dL332-R350)

### Task Interruption:
* Introduced a `stopRequested` flag in the `CParallelTask` class to allow tasks to be interrupted. Added `requestStop` and `isStopRequested` methods to manage this flag. (`src/core/utils/thread.h`)
* Updated worker threads in `CParallelTask` to periodically check for the `stopRequested` flag and terminate accordingly. (`src/core/utils/thread.h`)

### Integration with Progress Bars:
* Updated `HandlePakAssetExportList` and `HandleExportAllPakAssets` to include the `hasCloseButton` parameter when creating progress bar events, enabling task interruption. (`src/core/filehandling/rpak.cpp`) [[1]](diffhunk://#diff-822fe762e7a90063b75608cb6f224c9fe023e06773eb7524bb2fc303d5a24348L147-R147) [[2]](diffhunk://#diff-822fe762e7a90063b75608cb6f224c9fe023e06773eb7524bb2fc303d5a24348L168-R168)

These changes collectively enhance the application's responsiveness and provide users with more control over long-running operations.