### PR TITLE
fix: oodle pak decomp leak

### DIFF
--- a/src/game/rtech/cpakfile.cpp
+++ b/src/game/rtech/cpakfile.cpp
@@ -655,9 +655,6 @@ const bool CPakFile::DecompressFileBuffer(const char* fileBuffer, std::shared_pt
         // copy all of the decoded data into the decompressed buffer
         memcpy_s(dcmpBuf.get() + header->pakHdrSize, header->dcmpSize, data.get(), decodeSize);
 
-        // release the oodle decomp buffer now we are done with it
-        data.release();
-
         if (outBuffer->get() != nullptr)
             outBuffer->reset();
 


### PR DESCRIPTION
fixes the problematic ownership release of the oodle decompressed data creating a memory leak