### PR TITLE
Fix nondeterministic export output and several correctness bugs

### DIFF
--- a/src/core/mdl/modeldata_qc.cpp
+++ b/src/core/mdl/modeldata_qc.cpp
@@ -312,8 +312,10 @@ void QC_ParseStudioBone(qc::QCFile* const qc, const ModelParsedData_t* const par
 }
 
 constexpr const char* const s_QCModelNameFormat = "%s_%s%s\0"; // file name, model name, extension
-static uint32_t s_QCMaxVerts = 0u;
-void QC_ParseStudioBodypart(qc::QCFile* const qc, const ModelParsedData_t* const parsedData, const ModelBodyPart_t* const bodypart, const char* const stem, const int setting)
+// [rsx]: passed by reference instead of living in a global: exports run on multiple threads
+// and a shared global would race between two concurrent QC exports, writing a wrong $maxverts
+// value into one of the files.
+void QC_ParseStudioBodypart(qc::QCFile* const qc, const ModelParsedData_t* const parsedData, const ModelBodyPart_t* const bodypart, const char* const stem, const int setting, uint32_t& maxVerts)
 {
 	using namespace qc;
 
@@ -343,7 +345,7 @@ void QC_ParseStudioBodypart(qc::QCFile* const qc, const ModelParsedData_t* const
 
 		CmdParse(qc, QC_BODY, &bodyData, 1, true);
 
-		s_QCMaxVerts = modelData->vertCount > s_QCMaxVerts ? modelData->vertCount : s_QCMaxVerts;
+		maxVerts = modelData->vertCount > maxVerts ? modelData->vertCount : maxVerts;
 
 		return;
 	}
@@ -366,7 +368,7 @@ void QC_ParseStudioBodypart(qc::QCFile* const qc, const ModelParsedData_t* const
 
 		bodyGroupData.SetPart(qc, i, buf);
 
-		s_QCMaxVerts = modelData->vertCount > s_QCMaxVerts ? modelData->vertCount : s_QCMaxVerts;
+		maxVerts = modelData->vertCount > maxVerts ? modelData->vertCount : maxVerts;
 	}
 
 	CmdParse(qc, QC_BODYGROUP, &bodyGroupData, 1, true);
@@ -392,7 +394,7 @@ const uint32_t QC_ParseStudioLODBone(const ModelParsedData_t* const parsedData, 
 	return out;
 }
 
-void QC_ParseStudioLOD(qc::QCFile* const qc, const ModelParsedData_t* const parsedData, const size_t lod, const bool isShadowLOD, const char* const stem, const int setting)
+void QC_ParseStudioLOD(qc::QCFile* const qc, const ModelParsedData_t* const parsedData, const size_t lod, const bool isShadowLOD, const char* const stem, const int setting, uint32_t& maxVerts)
 {
 	using namespace qc;
 
@@ -431,7 +433,7 @@ void QC_ParseStudioLOD(qc::QCFile* const qc, const ModelParsedData_t* const pars
 
 		lodGroupData.ReplaceModel(qc, i, bufBase, bufReplace);
 
-		s_QCMaxVerts = modelData->vertCount > s_QCMaxVerts ? modelData->vertCount : s_QCMaxVerts;
+		maxVerts = modelData->vertCount > maxVerts ? modelData->vertCount : maxVerts;
 	}
 
 	// bones
@@ -1455,9 +1457,9 @@ bool ExportModelQC(const ModelParsedData_t* const parsedData, std::filesystem::p
 	for (int i = 0; i < parsedData->BoneCount(); i++)
 		QC_ParseStudioBone(&qcFile, parsedData, parsedData->pBone(i), version);
 
-	s_QCMaxVerts = 0u;
+	uint32_t maxVerts = 0u;
 	for (size_t i = 0; i < parsedData->bodyParts.size(); i++)
-		QC_ParseStudioBodypart(&qcFile, parsedData, parsedData->pBodypart(i), fileStem.c_str(), setting);
+		QC_ParseStudioBodypart(&qcFile, parsedData, parsedData->pBodypart(i), fileStem.c_str(), setting, maxVerts);
 
 	if (parsedData->lods.size() > 1)
 	{
@@ -1465,23 +1467,23 @@ bool ExportModelQC(const ModelParsedData_t* const parsedData, std::filesystem::p
 		{
 			if (parsedData->pStudioHdr()->flags & STUDIOHDR_FLAGS_HASSHADOWLOD && parsedData->pLOD(i)->switchPoint == -1.0f)
 			{
-				QC_ParseStudioLOD(&qcFile, parsedData, i, true, fileStem.c_str(), setting);
+				QC_ParseStudioLOD(&qcFile, parsedData, i, true, fileStem.c_str(), setting, maxVerts);
 				continue;
 			}
 
 
-			QC_ParseStudioLOD(&qcFile, parsedData, i, false, fileStem.c_str(), setting);
+			QC_ParseStudioLOD(&qcFile, parsedData, i, false, fileStem.c_str(), setting, maxVerts);
 		}
 	}
 
 	// do $maxverts command
-	s_QCMaxVerts++;
-	assertm(s_QCMaxVerts < s_MaxStudioVerts, "invalid max vert value");
+	maxVerts++;
+	assertm(maxVerts < s_MaxStudioVerts, "invalid max vert value");
 	
 	constexpr int maxVertThreshold = (s_MaxStudioVerts / 3);
-	if (s_QCMaxVerts > maxVertThreshold)
+	if (maxVerts > maxVertThreshold)
 	{
-		CmdParse(&qcFile, QC_MAXVERTS, &s_QCMaxVerts);
+		CmdParse(&qcFile, QC_MAXVERTS, &maxVerts);
 	}
 
 	// attachments

--- a/src/core/mdl/rmax.cpp
+++ b/src/core/mdl/rmax.cpp
@@ -281,7 +281,10 @@ namespace rmax
 
 	bool RMAXExporter::ToFile() const
 	{
-        char* buffer = new char[maxFileSize];
+        // [rsx]: zero initialize the buffer: ToFile() aligns section offsets with IALIGN16 and
+        // rounds the final file size up to 16 bytes, so the alignment gaps would otherwise be
+        // written to disk as uninitialized heap memory, making every export differ.
+        char* buffer = new char[maxFileSize]{};
 
         const bool success = ToFile(buffer);
 

--- a/src/core/render/dx.cpp
+++ b/src/core/render/dx.cpp
@@ -123,19 +123,46 @@ ID3D11ShaderResourceView* const CTexture::GetSRV()
     return m_shaderResourceView;
 }
 
+// [rsx]: exports run on multiple threads and the same texture can end up being written to the
+// same path by different export tasks (e.g. two materials sharing a texture, or two selected
+// assets sharing a dependency). serialize writes per output path so concurrent writers cannot
+// interleave within one file and produce corrupted/nondeterministic output.
+static std::mutex& GetExportPathLock(const std::filesystem::path& exportPath)
+{
+    static std::mutex s_pathLocks[64];
+    return s_pathLocks[std::filesystem::hash_value(exportPath) & 63];
+}
+
 bool CTexture::ExportAsPng(const std::filesystem::path& exportPath)
 {
+    const DirectX::ScratchImage* srcImage = ToScratchImage;
+    DirectX::ScratchImage convertedImage; // holds the pixels when a format conversion is needed
+
     if (!IsValid32bppFormat())
     {
-        const DXGI_FORMAT convertFormat = DirectX::IsSRGB(ToScratchImage->GetMetadata().format) ? DXGI_FORMAT_B8G8R8A8_UNORM_SRGB : DXGI_FORMAT_B8G8R8A8_UNORM;
-        if (!ConvertToFormat(convertFormat))
+        const DirectX::TexMetadata& meta = srcImage->GetMetadata();
+        const DXGI_FORMAT convertFormat = DirectX::IsSRGB(meta.format) ? DXGI_FORMAT_B8G8R8A8_UNORM_SRGB : DXGI_FORMAT_B8G8R8A8_UNORM;
+
+        // [rsx]: convert into a temporary image instead of converting this texture in place.
+        // CTexture objects can be shared (atlas textures are used by both the atlas export and
+        // the per-image slice exports), so an in place conversion would 1) make a later dds
+        // export write converted data instead of the original format and 2) race with other
+        // threads exporting the same texture.
+        const HRESULT convertRes = DirectX::IsCompressed(meta.format)
+            ? DirectX::Decompress(srcImage->GetImages(), srcImage->GetImageCount(), meta, convertFormat, convertedImage)
+            : DirectX::Convert(srcImage->GetImages(), srcImage->GetImageCount(), meta, convertFormat, DirectX::TEX_FILTER_FLAGS::TEX_FILTER_DEFAULT, DirectX::TEX_THRESHOLD_DEFAULT, convertedImage);
+
+        if (FAILED(convertRes))
         {
             assertm(false, "Converting the texture format failed.");
             return false;
         }
+
+        srcImage = &convertedImage;
     }
 
-    const HRESULT res = DirectX::SaveToWICFile(*ToScratchImage->GetImages(), DirectX::WIC_FLAGS::WIC_FLAGS_FORCE_SRGB, DirectX::GetWICCodec(DirectX::WICCodecs::WIC_CODEC_PNG), exportPath.wstring().c_str(), nullptr, 
+    std::lock_guard<std::mutex> writeLock(GetExportPathLock(exportPath));
+    const HRESULT res = DirectX::SaveToWICFile(*srcImage->GetImages(), DirectX::WIC_FLAGS::WIC_FLAGS_FORCE_SRGB, DirectX::GetWICCodec(DirectX::WICCodecs::WIC_CODEC_PNG), exportPath.wstring().c_str(), nullptr, 
         [](IPropertyBag2* props)
         {
             PROPBAG2 options{};
@@ -152,6 +179,7 @@ bool CTexture::ExportAsPng(const std::filesystem::path& exportPath)
 
 bool CTexture::ExportAsDds(const std::filesystem::path& exportPath)
 {
+    std::lock_guard<std::mutex> writeLock(GetExportPathLock(exportPath));
     return SUCCEEDED(DirectX::SaveToDDSFile(ToScratchImage->GetImages(), ToScratchImage->GetImageCount(), ToScratchImage->GetMetadata(), DirectX::DDS_FLAGS::DDS_FLAGS_NONE, exportPath.wstring().c_str()));
 }
 

--- a/src/core/utils/jsonutils.cpp
+++ b/src/core/utils/jsonutils.cpp
@@ -1,4 +1,4 @@
-//===== Copyright � 1999-2024, Kawe Mazidjatari, All rights reserved. =======//
+//===== Copyright (c) 1999-2024, Kawe Mazidjatari, All rights reserved. =====//
 //
 // Purpose: A set of utilities for RapidJSON
 //

--- a/src/core/utils/jsonutils.h
+++ b/src/core/utils/jsonutils.h
@@ -1,4 +1,4 @@
-//===== Copyright � 1999-2024, Kawe Mazidjatari, All rights reserved. =======//
+//===== Copyright (c) 1999-2024, Kawe Mazidjatari, All rights reserved. =====//
 //
 // Purpose: A set of utilities for RapidJSON
 //

--- a/src/game/rtech/assets/texture.cpp
+++ b/src/game/rtech/assets/texture.cpp
@@ -419,7 +419,7 @@ struct TexCompare_t
             {
             case TexturePreviewData_t::eColumnID::TPC_Level:        delta = (static_cast<short>(a.level) - b.level);                        break; // no overflow please
             case TexturePreviewData_t::eColumnID::TPC_Dimensions:   delta = (static_cast<short>(a.level) - b.level);                        break; // no overflow please
-            case TexturePreviewData_t::eColumnID::TPC_Type:         delta = (static_cast<short>(a.type) - static_cast<short>(b.level));     break;
+            case TexturePreviewData_t::eColumnID::TPC_Type:         delta = (static_cast<short>(a.type) - static_cast<short>(b.type));      break;
             case TexturePreviewData_t::eColumnID::TPC_Comp:         delta = (static_cast<short>(a.comp) - static_cast<short>(b.comp));     break;
             default: IM_ASSERT(0); break;
             }

--- a/src/game/rtech/assets/ui_image.cpp
+++ b/src/game/rtech/assets/ui_image.cpp
@@ -303,7 +303,7 @@ std::unique_ptr<CTexture> CreateBC1TextureForUIImageAsset(CPakAsset* const asset
 
             if (tile->opcode != BC1_FLAG) // Transparent tile, replace with our own.
             {
-                memcpy_s(bc1Buf.get() + tileOffset, bc1BufSize, UIImageTileBc1, sizeof(UIImageTileBc1));
+                memcpy_s(bc1Buf.get() + tileOffset, bc1BufSize - tileOffset, UIImageTileBc1, sizeof(UIImageTileBc1));
                 continue;
             }
 
@@ -372,7 +372,7 @@ std::unique_ptr<CTexture> CreateBC7TextureForUIImageAsset(CPakAsset* const asset
 
             if (tile->opcode != BC7_FLAG) // Transparent tile, replace with our own.
             {
-                memcpy_s(bc7Buf.get() + tileOffset, bc7BufSize, UIImageTileBc7, sizeof(UIImageTileBc7));
+                memcpy_s(bc7Buf.get() + tileOffset, bc7BufSize - tileOffset, UIImageTileBc7, sizeof(UIImageTileBc7));
                 continue;
             }
 
@@ -395,7 +395,7 @@ std::unique_ptr<CTexture> CreateBC7TextureForUIImageAsset(CPakAsset* const asset
     }
     else
     {
-        assertm(bc7Texture->GetSlicePitch() < bc7BufSize, "bc7Buf greater than our texture buf?");
+        assertm(bc7BufSize <= bc7Texture->GetSlicePitch(), "bc7Buf greater than our texture buf?");
         memcpy_s(bc7Texture->GetPixels(), bc7Texture->GetSlicePitch(), bc7Buf.get(), bc7BufSize);
 
         return std::move(bc7Texture);

--- a/src/game/rtech/assets/ui_image_atlas.cpp
+++ b/src/game/rtech/assets/ui_image_atlas.cpp
@@ -52,9 +52,11 @@ void LoadUIImageAtlasAsset(CAssetContainer* const pak, CAsset* const asset)
         // for fetching this from texture
         img.bounds = bounds + i;
 
-        // [rika]: should this have the same rounding as below ? todo study this
-		img.posX = static_cast<uint16_t>(img.bounds->minX * static_cast<float>(uiAsset->width));
-		img.posY = static_cast<uint16_t>(img.bounds->minY * static_cast<float>(uiAsset->height));
+        // [rsx]: round to nearest like the size calculation below. truncating can place the
+        // slice one pixel off when minX/minY * dimension lands just below a whole number
+        // (e.g. 99.99997 truncates to 99 instead of 100), shifting the exported image.
+		img.posX = static_cast<uint16_t>(img.bounds->minX * static_cast<float>(uiAsset->width) + 0.5f);
+		img.posY = static_cast<uint16_t>(img.bounds->minY * static_cast<float>(uiAsset->height) + 0.5f);
 
         // [rika]: size within the image, SampleLevel (shader) rounds to nearest fixed point (source: trust me bro), hence the + 0.5f
         // note: while at first glance it seems everything is fine, if for some reason artifacting or bad exporting happens check this first
@@ -264,7 +266,7 @@ void* PreviewUIImageAtlasAsset(CAsset* const asset, const bool firstFrameForAsse
             return nullptr;
 
         // This will be the main texture.
-        if (uiImage->width == uiAsset->width && uiImage->height == uiImage->height)
+        if (uiImage->width == uiAsset->width && uiImage->height == uiAsset->height)
             return uiAsset->rawTxtr;
 
         // invalid image

--- a/src/game/rtech/cpakfile.h
+++ b/src/game/rtech/cpakfile.h
@@ -1236,7 +1236,10 @@ public:
 
         file.seek(offset);
 
-        std::unique_ptr<char[]> data(new char[size]);
+        // [rsx]: zero initialize so a short read (requested sizes are page aligned and can
+        // exceed the end of the file for the last entry) leaves deterministic zeroes instead
+        // of uninitialized heap memory in the exported data.
+        std::unique_ptr<char[]> data(new char[size]{});
         file.read(data.get(), size);
 
         return data;

--- a/src/thirdparty/imgui/misc/imgui_utility.cpp
+++ b/src/thirdparty/imgui/misc/imgui_utility.cpp
@@ -635,7 +635,7 @@ void ImGuiHandler::HandleProgressBar()
         else
         {
             ImGui::Separator();
-            ImGui::Text(event->eventName);
+            ImGui::TextUnformatted(event->eventName);
         }
 
         const uint32_t numEvents = event->eventNum;


### PR DESCRIPTION
## Summary

Re-exporting the same asset could produce output files that differ by a few bytes/pixels on every run. I tracked this down to several independent sources of nondeterminism, plus a few adjacent correctness bugs found along the way. All are fixed in this PR; each fix is small and local.

### Nondeterministic export output

- **`cpakfile.h` `getStarPakData()`**: the destination buffer was allocated uninitialized and the stream read result was never validated. Requested mip sizes are page aligned, so reads near the end of a (opt)starpak can come up short, leaving random heap bytes in the tail of the exported texture data - a few random pixels that change on every run. The buffer is now zero initialized so short reads produce deterministic zeroes.
- **`rmax.cpp` `RMAXExporter::ToFile()`**: the 16 MiB scratch buffer was uninitialized, while the writer advances with `IALIGN16` after every data section and rounds the final file size up to 16 bytes. The alignment gaps were written to disk as heap garbage, so every exported `.rmax` differed. The buffer is now zero initialized.
- **`dx.cpp` `ExportAsPng()` / `ExportAsDds()`**: exports run on a thread pool, and two tasks can write the same output path (e.g. two materials sharing a texture with "Export Material Textures" enabled, or two selected assets sharing a dependency with "Export asset dependencies" enabled). Concurrent writers interleave within a single file and corrupt it differently each run. File writes are now serialized per output path through a small hashed mutex pool.
- **`modeldata_qc.cpp`**: `s_QCMaxVerts` was a file-scope global mutated by concurrent QC exports, so a parallel export could write another model's `$maxverts` value into the QC file. It is now a local passed by reference through `QC_ParseStudioBodypart` / `QC_ParseStudioLOD`.

### Shared texture mutation

- **`dx.cpp` `ExportAsPng()`** converted the texture to B8G8R8A8 *in place* via `ConvertToFormat`, which deletes and replaces the underlying scratch image. Atlas textures (`rawTxtr` / `convertedTxtr`) are shared between preview and both export paths, so exporting PNG first silently changed what a later DDS export wrote (converted data instead of the original block-compressed format), and two threads exporting the same texture raced on the delete/replace. The conversion now happens into a temporary `ScratchImage`, leaving the source texture untouched.

### One-pixel offset in ui image atlas slices

- **`ui_image_atlas.cpp`**: `posX`/`posY` were truncated while `width`/`height` were rounded to nearest (`+ 0.5f`). When `minX * atlasWidth` lands just below a whole number (e.g. `99.99997`), the slice origin came out one pixel off. The position now uses the same round-to-nearest as the size; this resolves the existing `// should this have the same rounding as below ? todo study this` note.
- Also fixed the always-true `uiImage->height == uiImage->height` comparison in the preview's main-texture check (should compare against `uiAsset->height`).

### Smaller fixes

- **`ui_image.cpp`**: the `memcpy_s` destination sizes for transparent tile fills did not subtract `tileOffset`; the BC7 slice-pitch assert compared in the wrong direction (BC1 branch had it right).
- **`texture.cpp`**: the mip table "Type" column sort compared `a.type` against `b.level`.
- **`imgui_utility.cpp`**: secondary progress bar names were passed to `ImGui::Text` as a format string; now `TextUnformatted`.
- **`jsonutils.h/.cpp`**: the copyright line contained an encoding-mangled character (U+FFFD). On systems with a non-western ANSI codepage (e.g. 936), MSVC raises C4819 which the project's warnings-as-errors turns into a build failure - `main` currently does not compile on such systems. Replaced with `(c)`.

Not addressed here (worth a follow-up): `RTech::DecompressStreamedBuffer` passes the *decompressed* size as the available input byte count to `OodleLZDecoder_DecodeSome`, which can over-read the compressed input buffer. Fixing it requires a signature change across many call sites.

## Test plan

- [x] Full rebuild of `Release_CI` succeeds (warnings-as-errors, /W4)
- [x] Exporting the same asset twice now produces byte-identical files (streamed textures, ui image atlas PNG/DDS, rmax)
- [x] DDS atlas export after PNG atlas export retains the original block-compressed format
- [x] Parallel "export all" with material textures + dependencies enabled produces stable output
