### PR TITLE
Fix Scene docking layout after Skin Finder was added

### DIFF
--- a/src/core/render.cpp
+++ b/src/core/render.cpp
@@ -338,7 +338,7 @@ void SettingsWnd_Draw(CUIState* uiState)
 
         ImGui::Combo("Compression Level", reinterpret_cast<int*>(&UtilsConfig->compressionLevel), s_CompressionLevelSetting, static_cast<int>(ARRAYSIZE(s_CompressionLevelSetting)));
         ImGui::SameLine();
-        ImGuiExt::HelpMarker("Specifies the compression level used when storing parsed assets in memory.\nWARNING: Modify only if you know what you’re doing; otherwise, you may run out of memory.\nNone: no compression.\nSuper Fast: Fastest level with the lowest compression ratio.\nVery Fast: Standard setting; fastest level with a decent compression ratio.\nFast: Fastest level with a good compression ratio.\nNormal: Standard LZ speed with the highest compression ratio.");
+        ImGuiExt::HelpMarker("Specifies the compression level used when storing parsed assets in memory.\nWARNING: Modify only if you know what you?re doing; otherwise, you may run out of memory.\nNone: no compression.\nSuper Fast: Fastest level with the lowest compression ratio.\nVery Fast: Standard setting; fastest level with a decent compression ratio.\nFast: Fastest level with a good compression ratio.\nNormal: Standard LZ speed with the highest compression ratio.");
 
         ImGui::SliderScalar("Parse Threads", ImGuiDataType_U32, &UtilsConfig->parseThreadCount, &minThreads, reinterpret_cast<int*>(&g_maxConcurrentThreadCount));
         ImGui::SameLine();
@@ -793,17 +793,21 @@ void HandleRenderFrame()
     {
         const ImGuiID dockspaceId = ImGui::GetID("MainDockSpace");
 
-        // If the dockspace hasn't been created yet
+        // If the dockspace hasn't been created yet.
+        // Build side panels first, then dock Scene/Skin Finder into the remaining
+        // central node and lock that node so the preview cannot be undocked.
         if (ImGui::DockBuilderGetNode(dockspaceId) == nullptr)
         {
             DockBuilder(dockspaceId)
-                .Window("Scene", true)
-                .Window("Skin Finder", true)
                 .DockLeft(0.25f)
                     .Window("Asset List")
                     .Done()
                 .DockRight(0.25f)
-                    .Window("Asset Info");
+                    .Window("Asset Info")
+                    .Done()
+                .Window("Scene", true)
+                .Window("Skin Finder", true)
+                .Finish();
         }
 
         ImGui::DockSpaceOverViewport(dockspaceId, NULL, ImGuiDockNodeFlags_PassthruCentralNode, 0);
@@ -1092,9 +1096,10 @@ void HandleRenderFrame()
     }
     if(!SHOW_WELCOME_BOX) ImGui::End();
 
-    // The "scene" preview window must always be in the center.
-    // Setting NoMove seems to be the best way to stop it from being undocked
-    if (!SHOW_WELCOME_BOX && ImGui::Begin("Scene", nullptr, ImGuiWindowFlags_NoMove))
+    // The "scene" preview window must always stay in the central dock node.
+    // Undocking is prevented via ImGuiDockNodeFlags_NoUndocking on that node
+    // (see DockBuilder layout above), so NoMove is not needed here.
+    if (!SHOW_WELCOME_BOX && ImGui::Begin("Scene"))
     {
         const ImVec2 avail = ImGui::GetContentRegionAvail();
 

--- a/src/thirdparty/imgui/misc/imgui_utility.h
+++ b/src/thirdparty/imgui/misc/imgui_utility.h
@@ -201,27 +201,39 @@ extern ImGuiHandler* g_pImGuiHandler;
 #include <string>
 
 // https://github.com/ocornut/imgui/issues/9169#issuecomment-3975678015
+//
+// Notes vs the original gallery helper:
+// - DockBuilderAddNode() is only called once. Calling it again for a second root
+//   Window() would RemoveNode() the dockspace and wipe earlier DockBuilderDockWindow
+//   assignments (this broke Scene after Skin Finder was added to the central node).
+// - lock applies ImGuiDockNodeFlags_NoUndocking to the current leaf node, not by
+//   recreating the dockspace.
+// - Finish() must be called on the root builder when the layout is complete.
 class DockBuilder
 {
 public:
     DockBuilder(ImGuiID parent_id, DockBuilder* parent = nullptr) :
         m_parentId{ parent_id },
+        m_rootId{ parent ? parent->m_rootId : parent_id },
         m_parent{ parent }
     {
-    }
-
-    DockBuilder& Window(const std::string& name, bool lock=false)
-    {
+        // Create the dockspace once when the root builder is constructed.
         if (m_parent == nullptr)
         {
-            ImGuiDockNodeFlags flags = ImGuiDockNodeFlags_DockSpace;
-            flags |= lock ? ImGuiDockNodeFlags_NoUndocking : 0;
-
-            ImGui::DockBuilderAddNode(m_parentId, flags);
+            ImGui::DockBuilderAddNode(m_parentId, ImGuiDockNodeFlags_DockSpace);
             ImGui::DockBuilderSetNodeSize(m_parentId, ImGui::GetMainViewport()->Size);
         }
+    }
 
+    DockBuilder& Window(const std::string& name, bool lock = false)
+    {
         ImGui::DockBuilderDockWindow(name.c_str(), m_parentId);
+
+        if (lock)
+        {
+            if (ImGuiDockNode* const node = ImGui::DockBuilderGetNode(m_parentId))
+                node->SetLocalFlags(node->LocalFlags | ImGuiDockNodeFlags_NoUndocking);
+        }
 
         return *this;
     }
@@ -265,29 +277,21 @@ public:
         return *m_parent;
     }
 
+    DockBuilder& Finish()
+    {
+        assert(m_parent == nullptr && "Finish() must be called on the root dock builder");
+        ImGui::DockBuilderFinish(m_rootId);
+        return *this;
+    }
+
 private:
     DockBuilder* m_parent;
     ImGuiID m_parentId;
+    ImGuiID m_rootId;
     std::unique_ptr<DockBuilder> m_left;
     std::unique_ptr<DockBuilder> m_right;
     std::unique_ptr<DockBuilder> m_top;
     std::unique_ptr<DockBuilder> m_bottom;
-
-    int NumOfNodes()
-    {
-        int count = 1; // count self
-
-        if (m_left != nullptr)
-            count++;
-        if (m_right != nullptr)
-            count++;
-        if (m_top != nullptr)
-            count++;
-        if (m_bottom != nullptr)
-            count++;
-
-        return count;
-    }
 };
 
 // https://github.com/libigl/libigl/issues/1300#issuecomment-1310174619


### PR DESCRIPTION
## Summary
- `DockBuilder::Window()` was calling `DockBuilderAddNode()` on every root-level window. `AddNode` removes the existing dockspace first, so docking **Skin Finder** after **Scene** wiped Scene's dock assignment and left the preview floating (while `NoMove` still blocked dragging it back into place).
- Create the dockspace once, dock Asset List / Asset Info into the side splits first, then dock Scene + Skin Finder into the remaining central node with `NoUndocking`.
- Remove the Scene `ImGuiWindowFlags_NoMove` workaround; the central node lock matches the original intent of keeping the preview fixed in the center.

## Test plan
- [ ] Fresh launch (or delete `imgui.ini`): Asset List left, Asset Info right, Scene centered
- [ ] Load a pak and select a model/texture - preview renders in the central Scene window
- [ ] Scene title bar cannot undock the preview out of the center
- [ ] Open Skin Finder - it tabs with Scene in the central node
- [ ] Asset List / Asset Info still behave normally (resize splitters, content)