### PR TITLE
fix(cli): run NoGui export tasks; apply load whitelist only when set

### DIFF
--- a/src/core/filehandling/load.cpp
+++ b/src/core/filehandling/load.cpp
@@ -37,6 +37,13 @@ static void CLI_HandleAssetTypeWhitelist(const CCommandLine* const cli)
     if (!IS_NOGUI(cli))
         return;
 
+    // Only apply the whitelist when --loadwhitelist was actually given.
+    // Unconditionally setting _loadAssetType = filterTypes.contains(fourCC)
+    // with an empty set disables every asset type on a normal nogui run
+    // (no loads, no post-loads, no exports).
+    if (!cli->GetParamValue("--loadwhitelist"))
+        return;
+
     const std::unordered_set<uint32_t> filterTypes = CLI_GetCommaSeparatedAssetTypes(cli, "--loadwhitelist");
 
     for (auto& [fourCC, binding] : g_assetData.m_assetTypeBindings)

--- a/src/core/filehandling/rpak.cpp
+++ b/src/core/filehandling/rpak.cpp
@@ -178,8 +178,13 @@ void HandlePakAssetExportList(std::deque<CAsset*> selectedAssets, const bool exp
         parallelProcessTask.getRemainingTasks(),
         &parallelProcessTask,
         PB_FNCLASS_TO_VOID(&CParallelTask::getRemainingTasks));
+#endif
+    // execute()/wait() must run in NoGui builds too. Leaving them inside the
+    // BUILD_NOGUI guard queues export tasks that never run (CLI -export writes
+    // zero files and exits 0).
     parallelProcessTask.execute();
     parallelProcessTask.wait();
+#if !defined(BUILD_NOGUI)
     g_pImGuiHandler->FinishProgressBarEvent(exportAssetListEvent);
 
     g_bridgeData.PostNotification("", std::format("Exported {} asset{}!", selectedAssets.size(), selectedAssets.size() == 1 ? "" : "s"));
@@ -209,8 +214,11 @@ void HandleExportAllPakAssets(std::vector<CGlobalAssetData::AssetLookup_t>* cons
         &parallelProcessTask,
         PB_FNCLASS_TO_VOID(&CParallelTask::getRemainingTasks)
     );
+#endif
+    // Same as HandlePakAssetExportList: export work must not be NoGui-only.
     parallelProcessTask.execute();
     parallelProcessTask.wait();
+#if !defined(BUILD_NOGUI)
     g_pImGuiHandler->FinishProgressBarEvent(exportAllAssetsEvent);
 #endif
 }


### PR DESCRIPTION
## Summary

Fixes two CLI / `BUILD_NOGUI` bugs that make headless export silently no-op on current `main`.

1. **NoGui export never runs** (`rpak.cpp`): `parallelProcessTask.execute()` / `.wait()` lived inside `#if !defined(BUILD_NOGUI)` next to the ImGui progress bar. CLI builds queued tasks and never ran them (zero files, exit 0). Progress UI stays NoGui-gated; only the actual work is always executed.

2. **Missing `--loadwhitelist` disables all types** (`load.cpp`): `CLI_HandleAssetTypeWhitelist` always rewrote `_loadAssetType` from the whitelist set. With the flag omitted the set is empty, so `contains()` turns every binding off. Early-return when the param is not set restores the default "load all registered types" behavior.

GUI builds are unchanged in behavior (export still runs; whitelist still only applies on NoGui when requested).

Closes #76

## Test plan

- [ ] Build `Release_NoGui`
- [ ] Without `--loadwhitelist`: load a small `.rpak` and confirm assets appear / types load (not zero assets)
- [ ] `rsx -export --exporttypes <type> --exportdir <dir> <pak>`: files actually written under `--exportdir`, exit 0
- [ ] With `--loadwhitelist <type>`: only that type loads
- [ ] Build / smoke GUI path still exports from the UI if convenient
