### PR TITLE
fix: keep all asset types enabled when --loadwhitelist is omitted

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -34,6 +34,7 @@ These arguments do not take a value. Including them in the arguments provided to
 | --qcminor       | (16-bit integer)                               | When exporting models as [SMD](./assets/rpak/Model.md#smd), sets the minor version of the QC file                |
 | --exportdir     | (string, directory path)                       | Sets the directory that all assets are exported to                                                               |
 | --exporttypes   | (string, [asset type](./AssetTypes.md))        | If the `-export` flag is specified, Sets a list of types that should be exported                                 |
+| --loadwhitelist | (string, [asset type](./AssetTypes.md))        | nogui only: parse/load only these types (comma-separated). If omitted, all types stay enabled                    |
 | --exportthreads | (integer, min: `1`, default: `1`)              | Sets the number of threads to use for exporting. Clamped to the number of threads supported by the processor     |
 | --parsethreads  | (integer, min: `1`, default: `0.5*maxThreads`) | Sets the number of threads to use for loading files. Clamped to the number of threads supported by the processor |
 | --list | (string, file path) | Sets the file path that the loaded asset list will be saved as |

--- a/src/core/filehandling/load.cpp
+++ b/src/core/filehandling/load.cpp
@@ -37,7 +37,19 @@ static void CLI_HandleAssetTypeWhitelist(const CCommandLine* const cli)
     if (!IS_NOGUI(cli))
         return;
 
+    // Omitted --loadwhitelist must keep the default (_loadAssetType = true).
+    // Treating a missing flag as an empty set disabled every type, so nogui
+    // -export skipped loadFunc/exportFunc and wrote no files with no error.
+    const char* const typeString = cli->GetParamValue("--loadwhitelist");
+    if (!typeString)
+        return;
+
     const std::unordered_set<uint32_t> filterTypes = CLI_GetCommaSeparatedAssetTypes(cli, "--loadwhitelist");
+
+    printf("LOAD: Applying --loadwhitelist \"%s\" (%lld valid type%s)\n",
+        typeString,
+        static_cast<long long>(filterTypes.size()),
+        filterTypes.size() == 1 ? "" : "s");
 
     for (auto& [fourCC, binding] : g_assetData.m_assetTypeBindings)
     {


### PR DESCRIPTION
## Problem
In nogui builds, `CLI_HandleAssetTypeWhitelist` always runs. If
`--loadwhitelist` is not passed, the filter is an empty set and every
asset type gets `_loadAssetType = false`.

Export then skips `exportFunc`. The documented command
`-nogui -export --exporttypes uiia ...` exits 0, prints
"Filtering ... (1 valid type)", and writes no files.

## Fix
If `--loadwhitelist` is omitted, return and keep the default
(`_loadAssetType = true`). Passing the flag still restricts parse/load.

Also document `--loadwhitelist` in `docs/CLI.md`.

## Test
rsx -export --exporttypes uiia --exportdir out mp_rr_desertlands_mu5.rpak
Now writes `uiia/ui_image/0x....png`. `--loadwhitelist uiia` still works.